### PR TITLE
Fixes compile bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
     </parent>
 
     <properties>
-        <brokerVersion>2.4.2</brokerVersion>
-        <brokerTestVersion>2.4.1</brokerTestVersion>
+        <brokerVersion>2.5.0</brokerVersion>
+        <brokerTestVersion>2.5.0</brokerTestVersion>
         <start-class>org.trustedanalytics.servicebroker.hdfs.config.Application</start-class>
         <jacoco-measurement-instructions>0.6069</jacoco-measurement-instructions>
         <jacoco-measurement-branches>0.2000</jacoco-measurement-branches>
@@ -97,6 +97,13 @@
         </plugins>
     </build>
 
+    <repositories>
+        <repository>
+            <id>cloudera</id>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- tag::jetty[] -->
         <dependency>
@@ -117,13 +124,13 @@
         <dependency>
             <groupId>org.trustedanalytics.servicebroker.repository</groupId>
             <artifactId>broker-store-commons</artifactId>
-            <version>0.4.4</version>
+            <version>0.5.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.trustedanalytics.servicebroker.repository</groupId>
             <artifactId>hdfs-broker-store</artifactId>
-            <version>0.4.8</version>
+            <version>0.5.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>
@@ -210,7 +217,7 @@
         <dependency>
             <groupId>org.trustedanalytics</groupId>
             <artifactId>hadoop-utils</artifactId>
-            <version>0.4.6</version>
+            <version>0.5.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/trustedanalytics/servicebroker/hdfs/config/ServiceInstanceBindingServiceConfig.java
+++ b/src/main/java/org/trustedanalytics/servicebroker/hdfs/config/ServiceInstanceBindingServiceConfig.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import org.trustedanalytics.cfbroker.store.api.BrokerStore;
 import org.trustedanalytics.cfbroker.store.impl.ServiceInstanceBindingServiceStore;
 import org.trustedanalytics.hadoop.config.*;
+import org.trustedanalytics.hadoop.config.internal.*;
 import org.trustedanalytics.servicebroker.hdfs.service.HdfsServiceInstanceBindingService;
 import org.cloudfoundry.community.servicebroker.model.CreateServiceInstanceBindingRequest;
 import org.cloudfoundry.community.servicebroker.service.ServiceInstanceBindingService;


### PR DESCRIPTION
1. Change broker-store-commons version to 0.5.0
   As of aa136b5, the master branch version is 0.5.0
2. Change spring-boot-cf-service-broker to 2.5.0
   The current version is 2.5.0
   https://github.com/cloudfoundry-community/spring-boot-cf-service-broker/blob/master/build.gradle#L18
3. Add CDH5 Maven repository
4. Import org.trustedanalytics.hadoop.config.internal.*
